### PR TITLE
Fix tree builder without a root deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,9 +30,14 @@ class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-
+        $tree = new TreeBuilder($this->name);
         $rootNode = $tree->root($this->name);
+        if (\method_exists($tree, 'getRootNode')) {
+            $rootNode = $tree->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $tree->root($this->name);
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.